### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: Release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/fatred/yubivault/security/code-scanning/3](https://github.com/fatred/yubivault/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to provide the least privileges required for the workflow to function correctly. Based on the tasks performed:
- `contents: read` is sufficient for accessing repository files.
- `contents: write` is needed for creating GitHub releases.
- Additional permissions like `pull-requests: write` are not necessary in this workflow.

This `permissions` block will be added at the root of the workflow file, applying to all jobs unless overridden by job-level `permissions`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
