### PR TITLE
Fix/pkcs11 resource lifecycle

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,19 @@ type VaultAuthClient interface {
 	io.Closer
 }
 
+// LocalVaultClient wraps a Vault client for filesystem-based certificate auth
+type LocalVaultClient struct {
+	VaultClient *vault.Client
+}
+
+func (c *LocalVaultClient) GetVaultClient() *vault.Client {
+	return c.VaultClient
+}
+
+func (c *LocalVaultClient) Close() error {
+	return nil // no resources to clean up for local auth
+}
+
 type VaultClient interface {
 	CertLogin(ctx context.Context, req schema.CertLoginRequest, opts ...vault.RequestOption) (*vault.Response[map[string]interface{}], error)
 	SetToken(token string) error

--- a/main.go
+++ b/main.go
@@ -35,6 +35,12 @@ type AppConfig struct {
 	YubikeyPivIndex  int    `yaml:"yubikeyPivIndex"`
 }
 
+// VaultAuthClient provides a unified interface for both local and YubiKey auth modes
+type VaultAuthClient interface {
+	GetVaultClient() *vault.Client
+	io.Closer
+}
+
 type VaultClient interface {
 	CertLogin(ctx context.Context, req schema.CertLoginRequest, opts ...vault.RequestOption) (*vault.Response[map[string]interface{}], error)
 	SetToken(token string) error

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func ReadPin(yubikeySerial string, r io.Reader) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(bPin), nil
+		return strings.TrimSpace(string(bPin)), nil
 	}
 	bPin := make([]byte, 64)
 	n, err := r.Read(bPin)
@@ -224,7 +224,7 @@ func ReadPin(yubikeySerial string, r io.Reader) (string, error) {
 	if err != nil && err != io.EOF {
 		return "", err
 	}
-	return string(bPin[:n]), nil
+	return strings.TrimSpace(string(bPin[:n])), nil
 }
 
 func AuthenticateAndGetToken(client VaultClient, appConfig *AppConfig, ctx context.Context) (string, error) {

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func LoadConfig(homeDir string) (*AppConfig, error) {
 	return appConfig, nil
 }
 
-func CreateLocalVaultClient(appConfig *AppConfig, homeDir string) (*vault.Client, error) {
+func CreateLocalVaultClient(appConfig *AppConfig, homeDir string) (*LocalVaultClient, error) {
 	tlsConfig := vault.TLSConfiguration{}
 	tlsConfig.ClientCertificate.FromFile = homeDir + "/.yubivault/" + appConfig.CertAuthPemFile
 	tlsConfig.ClientCertificateKey.FromFile = homeDir + "/.yubivault/" + appConfig.CertAuthKeyFile
@@ -118,7 +118,7 @@ func CreateLocalVaultClient(appConfig *AppConfig, homeDir string) (*vault.Client
 	if err != nil {
 		return nil, err
 	}
-	return client, nil
+	return &LocalVaultClient{VaultClient: client}, nil
 }
 
 func CreateYubikeyVaultClient(appConfig *AppConfig) (*vault.Client, *crypto11.Context, error) {

--- a/main.go
+++ b/main.go
@@ -54,6 +54,24 @@ func (c *LocalVaultClient) Close() error {
 	return nil // no resources to clean up for local auth
 }
 
+// YubikeyVaultClient wraps both Vault client and crypto11.Context
+// ensuring PKCS#11 resources are properly cleaned up
+type YubikeyVaultClient struct {
+	VaultClient *vault.Client
+	cryptoCtx   *crypto11.Context // unexported, owned by this struct
+}
+
+func (c *YubikeyVaultClient) GetVaultClient() *vault.Client {
+	return c.VaultClient
+}
+
+func (c *YubikeyVaultClient) Close() error {
+	if c.cryptoCtx != nil {
+		return c.cryptoCtx.Close()
+	}
+	return nil
+}
+
 type VaultClient interface {
 	CertLogin(ctx context.Context, req schema.CertLoginRequest, opts ...vault.RequestOption) (*vault.Response[map[string]interface{}], error)
 	SetToken(token string) error

--- a/main_test.go
+++ b/main_test.go
@@ -141,7 +141,7 @@ func TestReadPin_Mock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pin != "123456\n" {
+	if pin != "123456" {
 		t.Errorf("expected pin '123456\\n', got %q", pin)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -160,3 +160,16 @@ func TestLocalVaultClient_Interface(t *testing.T) {
 		t.Errorf("Close returned error: %v", err)
 	}
 }
+
+func TestYubikeyVaultClient_Interface(t *testing.T) {
+	// Verify YubikeyVaultClient satisfies VaultAuthClient
+	var _ VaultAuthClient = (*YubikeyVaultClient)(nil)
+}
+
+func TestYubikeyVaultClient_CloseNil(t *testing.T) {
+	// Edge case: Close with nil context should not panic
+	client := &YubikeyVaultClient{cryptoCtx: nil}
+	if err := client.Close(); err != nil {
+		t.Errorf("Close with nil context failed: %v", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -145,3 +145,18 @@ func TestReadPin_Mock(t *testing.T) {
 		t.Errorf("expected pin '123456\\n', got %q", pin)
 	}
 }
+
+func TestLocalVaultClient_Interface(t *testing.T) {
+	// Verify LocalVaultClient satisfies VaultAuthClient
+	var _ VaultAuthClient = (*LocalVaultClient)(nil)
+
+	client := &LocalVaultClient{VaultClient: &vault.Client{}}
+
+	if client.GetVaultClient() == nil {
+		t.Error("GetVaultClient returned nil")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+}


### PR DESCRIPTION
# Fix critical PKCS#11 resource leak in YubiKey authentication

  ## Summary

  This PR fixes a critical resource leak in `CreateYubikeyVaultClient()` that could leave YubiKey devices locked when authentication fails. The fix introduces wrapper types with guaranteed cleanup using Go's `io.Closer` pattern and unifies handling of both local and YubiKey authentication modes.

  ## Problem

  The current `CreateYubikeyVaultClient()` implementation has a critical bug: if any operation fails after `crypto11.Configure()` succeeds (e.g., `FindAllKeyPairs()`, `FindAllPairedCertificates()`, or `vault.New()`), the crypto11.Context is never closed. This leaks PKCS#11 resources and can lock the YubiKey, requiring hardware removal/reinsertion.

  **Additional issues fixed:**
  - Array bounds panic when no paired certificates found
  - Ignored error from `os.UserHomeDir()`
  - Inconsistent PIN trimming between interactive and test paths
  - Asymmetric handling of local vs YubiKey auth modes in `main()`

  ## Solution

  ### 1. Introduced VaultAuthClient Interface

  Created a unified interface that both authentication modes implement:

  ```go
  type VaultAuthClient interface {
      GetVaultClient() *vault.Client
      io.Closer
  }

  This enables symmetric handling with guaranteed cleanup via io.Closer.

  2. Wrapper Types with Resource Ownership

  - LocalVaultClient: Wraps *vault.Client for filesystem-based auth (no-op Close)
  - YubikeyVaultClient: Wraps both *vault.Client and *crypto11.Context with proper Close() implementation

  The cryptoCtx field is unexported to enforce lifecycle management through the wrapper.

  3. Deferred Cleanup Pattern

  Added critical deferred cleanup in CreateYubikeyVaultClient():

  defer func() {
      if err != nil && cryptoCtx != nil {
          cryptoCtx.Close()
      }
  }()

  This guarantees that on any error path after context creation, the PKCS#11 resources are automatically released. On success, ownership transfers to the wrapper.

  4. Unified main() Function

  Refactored main() to use the interface, eliminating asymmetric handling:

  var authClient VaultAuthClient
  if *localFlag {
      authClient, err = CreateLocalVaultClient(appConfig, homeDir)
  } else {
      authClient, err = CreateYubikeyVaultClient(appConfig)
  }
  if err != nil {
      log.Fatal(err)
  }
  defer authClient.Close()  // Single defer works for both modes!

  Changes Made

  Core Implementation

  - Added VaultAuthClient interface (main.go:38-41)
  - Added LocalVaultClient wrapper type (main.go:43-56)
  - Added YubikeyVaultClient wrapper type (main.go:58-73)
  - Updated CreateLocalVaultClient to return wrapper (main.go:109-122)
  - CRITICAL: Added deferred cleanup to CreateYubikeyVaultClient (main.go:152-156)
  - Added array bounds check before accessing certs[0] (main.go:175-177)
  - Refactored main() to use unified interface (main.go:256-299)
  - Fixed os.UserHomeDir() error handling (main.go:268-271)
  - Consistent PIN trimming in ReadPin() (main.go:219, 227)

  Testing

  - Added interface compliance tests (main_test.go:149-175)
  - Added table-driven error path tests (main_test.go:177-226)
  - Updated PIN trimming test expectations (main_test.go:144)
  - All 13 tests passing ✅

  Documentation

  - Updated CLAUDE.md with new architecture details
  - Documented deferred cleanup pattern
  - Documented wrapper types and their purpose

  Test Results

  === RUN   TestAuthenticateAndGetToken_Success
  --- PASS: TestAuthenticateAndGetToken_Success (0.00s)
  === RUN   TestLocalVaultClient_Interface
  --- PASS: TestLocalVaultClient_Interface (0.00s)
  === RUN   TestYubikeyVaultClient_Interface
  --- PASS: TestYubikeyVaultClient_Interface (0.00s)
  === RUN   TestYubikeyVaultClient_CloseNil
  --- PASS: TestYubikeyVaultClient_CloseNil (0.00s)
  === RUN   TestCreateYubikeyVaultClient_ErrorPaths
  --- PASS: TestCreateYubikeyVaultClient_ErrorPaths (0.00s)
  ... (8 more tests)
  PASS
  ok      github.com/fatred/yubivault     0.204s

  Coverage: 39.7% of statements

  Breaking Changes

  ⚠️ Function Signatures Changed (internal-only, no external API):
  - CreateLocalVaultClient() now returns (*LocalVaultClient, error) instead of (*vault.Client, error)
  - CreateYubikeyVaultClient() now returns (*YubikeyVaultClient, error) instead of (*vault.Client, *crypto11.Context, error)

  Since this is a CLI tool with no public API, these changes only affect the internal implementation.

  Verification

  - ✅ All tests pass (13/13)
  - ✅ Code compiles without errors
  - ✅ Binary builds successfully
  - ✅ go vet reports no issues
  - ✅ Version command works: ./yubivault -version → dev

  Related Issues

  Addresses the critical PKCS#11 resource leak identified in the code review, preventing YubiKey lockup scenarios in production.

  ---
  Generated with https://claude.com/claude-code using the superpowers:subagent-driven-development skill 🚀