### PR TITLE
Security hardening: fail-secure config/key handling + reliable YubiKey credential selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ openscPath: "/opt/homebrew/Cellar/opensc/0.26.1/lib/pkcs11/opensc-pkcs11.so"
 # openscPath: "/usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11.so"
 yubikeySerial: "12345678"
 yubikeyPivSerial: "1234567890123456"
-yubikeyPivLabel: "jhow-yubikey-12345678"
-yubikeyPivIndex: 0
+# optional: only needed when the card holds more than one credential.
+# Set it to the certificate Subject CN of the credential you want.
+# yubikeyCertCN: "network_admin_g2"
 ```
 
 4a. for local auth: put valid cert/key pair into that path

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ simple binary that will use a local cert/key pair on disk or on a yubikey to log
   a. macOS: `brew install opensc`
   b. linux: `apt install opensc` # or whatever your package manager is...
 1. Make a folder called `mkdir -p ~/.yubivault`
-2. Chown that to you only `chown -R 700 ~/.yubivault`
+2. Restrict it to you only `chmod 700 ~/.yubivault` (and `chmod 600` the key file)
 3. Make a config file:
 
 ```yaml

--- a/main.go
+++ b/main.go
@@ -138,6 +138,49 @@ func CreateLocalVaultClient(appConfig *AppConfig, homeDir string) (*LocalVaultCl
 	return &LocalVaultClient{VaultClient: client}, nil
 }
 
+// selectCertificate picks one paired credential from the card. With no wantCN and exactly
+// one pair, that pair is used. Otherwise the pair whose certificate Subject CommonName
+// equals wantCN is used. Ambiguity or no match is an error that names the fix. Selection is
+// on the parsed x509 cert (reliable), never on PKCS#11 labels.
+func selectCertificate(pairs []tls.Certificate, wantCN string) (tls.Certificate, error) {
+	if len(pairs) == 0 {
+		return tls.Certificate{}, fmt.Errorf("no paired credentials found on YubiKey")
+	}
+	if wantCN == "" {
+		if len(pairs) == 1 {
+			return pairs[0], nil
+		}
+		return tls.Certificate{}, fmt.Errorf("multiple credentials on card; set yubikeyCertCN to one of: %s", certCNs(pairs))
+	}
+	var matches []tls.Certificate
+	for _, p := range pairs {
+		if p.Leaf != nil && p.Leaf.Subject.CommonName == wantCN {
+			matches = append(matches, p)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return tls.Certificate{}, fmt.Errorf("no credential with CN %q; available: %s", wantCN, certCNs(pairs))
+	default:
+		return tls.Certificate{}, fmt.Errorf("multiple credentials with CN %q on card; cannot disambiguate", wantCN)
+	}
+}
+
+// certCNs renders the Subject CommonNames of the paired certs for error messages.
+func certCNs(pairs []tls.Certificate) string {
+	names := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		if p.Leaf == nil {
+			names = append(names, "<no leaf>")
+			continue
+		}
+		names = append(names, fmt.Sprintf("%q", p.Leaf.Subject.CommonName))
+	}
+	return strings.Join(names, ", ")
+}
+
 func CreateYubikeyVaultClient(appConfig *AppConfig) (*YubikeyVaultClient, error) {
 	var err error
 	var cryptoCtx *crypto11.Context

--- a/main.go
+++ b/main.go
@@ -103,13 +103,30 @@ func LoadConfig(homeDir string) (*AppConfig, error) {
 	if err := decoder.Decode(&appConfig); err != nil {
 		return nil, err
 	}
+	// Reject incomplete config up front rather than producing confusing
+	// downstream errors. Scheme is not enforced: cert-login needs a TLS
+	// handshake, so an http:// endpoint fails safely on its own, and local
+	// dev Vault (http://localhost:8200) stays usable.
+	if appConfig.VaultAddr == "" {
+		return nil, fmt.Errorf("vaultAddr is required")
+	}
+	if appConfig.CertAuthName == "" || appConfig.CertAuthMount == "" {
+		return nil, fmt.Errorf("certAuthName and certAuthMount are required")
+	}
 	return appConfig, nil
 }
 
 func CreateLocalVaultClient(appConfig *AppConfig, homeDir string) (*LocalVaultClient, error) {
 	tlsConfig := vault.TLSConfiguration{}
 	tlsConfig.ClientCertificate.FromFile = homeDir + "/.yubivault/" + appConfig.CertAuthPemFile
-	tlsConfig.ClientCertificateKey.FromFile = homeDir + "/.yubivault/" + appConfig.CertAuthKeyFile
+	keyPath := homeDir + "/.yubivault/" + appConfig.CertAuthKeyFile
+	tlsConfig.ClientCertificateKey.FromFile = keyPath
+	// Refuse to use a private key that group/other can read (fail-secure).
+	if info, err := os.Stat(keyPath); err != nil {
+		return nil, fmt.Errorf("could not stat key file: %w", err)
+	} else if info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("private key %s is accessible by group/other (mode %#o); run: chmod 600 %s", keyPath, info.Mode().Perm(), keyPath)
+	}
 	client, err := vault.New(
 		vault.WithAddress(appConfig.VaultAddr),
 		vault.WithTLS(tlsConfig),
@@ -162,7 +179,7 @@ func CreateYubikeyVaultClient(appConfig *AppConfig) (*YubikeyVaultClient, error)
 	if len(kps) == 0 {
 		return nil, fmt.Errorf("no key pairs found on YubiKey")
 	}
-	if appConfig.YubikeyPivIndex >= len(kps) {
+	if appConfig.YubikeyPivIndex < 0 || appConfig.YubikeyPivIndex >= len(kps) {
 		return nil, fmt.Errorf("yubikeyPivIndex %d out of range (found %d key pairs)", appConfig.YubikeyPivIndex, len(kps))
 	}
 	signer := kps[appConfig.YubikeyPivIndex]

--- a/main.go
+++ b/main.go
@@ -31,8 +31,7 @@ type AppConfig struct {
 	OpenScPath       string `yaml:"openscPath"`
 	YubikeySerial    string `yaml:"yubikeySerial"`
 	YubikeyPivSerial string `yaml:"yubikeyPivSerial"`
-	YubikeyPivLabel  string `yaml:"yubikeyPivLabel"`
-	YubikeyPivIndex  int    `yaml:"yubikeyPivIndex"`
+	YubikeyCertCN    string `yaml:"yubikeyCertCN"`
 }
 
 // VaultAuthClient provides a unified interface for both local and YubiKey auth modes
@@ -215,32 +214,15 @@ func CreateYubikeyVaultClient(appConfig *AppConfig) (*YubikeyVaultClient, error)
 		}
 	}()
 
-	kps, err := cryptoCtx.FindAllKeyPairs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to find key pairs: %w", err)
-	}
-	if len(kps) == 0 {
-		return nil, fmt.Errorf("no key pairs found on YubiKey")
-	}
-	if appConfig.YubikeyPivIndex < 0 || appConfig.YubikeyPivIndex >= len(kps) {
-		return nil, fmt.Errorf("yubikeyPivIndex %d out of range (found %d key pairs)", appConfig.YubikeyPivIndex, len(kps))
-	}
-	signer := kps[appConfig.YubikeyPivIndex]
-
-	certs, err := cryptoCtx.FindAllPairedCertificates()
+	// crypto11 pairs each private key with its certificate by CKA_ID (the PIV slot),
+	// so every returned tls.Certificate already has the correct key+cert bound together.
+	pairs, err := cryptoCtx.FindAllPairedCertificates()
 	if err != nil {
 		return nil, fmt.Errorf("could not search for certificates: %w", err)
 	}
-	// Array bounds check: prevent panic if no certificates found
-	if len(certs) == 0 {
-		return nil, fmt.Errorf("no paired certificates found on YubiKey")
-	}
-	cert := certs[0]
-
-	tlsCert := tls.Certificate{
-		Certificate: cert.Certificate,
-		PrivateKey:  signer,
-		Leaf:        cert.Leaf,
+	tlsCert, err := selectCertificate(pairs, appConfig.YubikeyCertCN)
+	if err != nil {
+		return nil, err
 	}
 
 	tlsConfig := &tls.Config{

--- a/main_test.go
+++ b/main_test.go
@@ -153,8 +153,12 @@ func TestLoadConfig_RejectsMissingAuthFields(t *testing.T) {
 
 func TestCreateLocalVaultClient_RejectsWorldReadableKey(t *testing.T) {
 	dir := t.TempDir()
-	os.Mkdir(dir+"/.yubivault", 0755)
-	os.WriteFile(dir+"/.yubivault/client-cert.key", []byte("dummy"), 0644)
+	dotDir := dir + "/.yubivault"
+	os.Mkdir(dotDir, 0700)
+	os.Chmod(dotDir, 0700) // match documented ~/.yubivault perms, defeat umask
+	keyPath := dotDir + "/client-cert.key"
+	os.WriteFile(keyPath, []byte("dummy"), 0644)
+	os.Chmod(keyPath, 0644) // defeat umask so the test actually exercises the rejection path
 
 	appConfig := &AppConfig{
 		VaultAddr:       "https://localhost:8200",

--- a/main_test.go
+++ b/main_test.go
@@ -227,8 +227,8 @@ func TestCreateYubikeyVaultClient_ErrorPaths(t *testing.T) {
 			expectErr: "could not read PIN code",
 		},
 		{
-			name:     "invalid OpenSC path",
-			setupEnv: func() { os.Setenv("TOKEN_PIN", "123456") },
+			name:       "invalid OpenSC path",
+			setupEnv:   func() { os.Setenv("TOKEN_PIN", "123456") },
 			cleanupEnv: func() { os.Unsetenv("TOKEN_PIN") },
 			appConfig: &AppConfig{
 				OpenScPath:       "/nonexistent/path.so",

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"os"
 	"strings"
@@ -248,6 +251,47 @@ func TestCreateYubikeyVaultClient_ErrorPaths(t *testing.T) {
 
 			if !strings.Contains(err.Error(), tt.expectErr) {
 				t.Errorf("expected error containing %q, got %q", tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func pairWithCN(cn string) tls.Certificate {
+	return tls.Certificate{Leaf: &x509.Certificate{Subject: pkix.Name{CommonName: cn}}}
+}
+
+func TestSelectCertificate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pairs   []tls.Certificate
+		wantCN  string
+		wantErr string // substring; "" means expect success
+		gotCN   string // expected CN of the returned cert on success
+	}{
+		{name: "no pairs", pairs: nil, wantErr: "no paired credentials"},
+		{name: "single pair, no CN", pairs: []tls.Certificate{pairWithCN("admin")}, gotCN: "admin"},
+		{name: "single pair, matching CN", pairs: []tls.Certificate{pairWithCN("admin")}, wantCN: "admin", gotCN: "admin"},
+		{name: "single pair, mismatched CN", pairs: []tls.Certificate{pairWithCN("admin")}, wantCN: "nope", wantErr: "no credential with CN"},
+		{name: "multiple pairs, no CN", pairs: []tls.Certificate{pairWithCN("a"), pairWithCN("b")}, wantErr: "set yubikeyCertCN"},
+		{name: "multiple pairs, unique match", pairs: []tls.Certificate{pairWithCN("a"), pairWithCN("b")}, wantCN: "b", gotCN: "b"},
+		{name: "multiple pairs, duplicate CN", pairs: []tls.Certificate{pairWithCN("dup"), pairWithCN("dup")}, wantCN: "dup", wantErr: "cannot disambiguate"},
+		{name: "multiple pairs, CN matches none", pairs: []tls.Certificate{pairWithCN("a"), pairWithCN("b")}, wantCN: "c", wantErr: "no credential with CN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectCertificate(tt.pairs, tt.wantCN)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Leaf == nil || got.Leaf.Subject.CommonName != tt.gotCN {
+				t.Errorf("expected returned CN %q, got %+v", tt.gotCN, got.Leaf)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -135,6 +135,34 @@ certAuthMount: "cert"
 	}
 }
 
+func TestLoadConfig_RejectsMissingAuthFields(t *testing.T) {
+	dir := t.TempDir()
+	configPath := dir + "/.yubivault"
+	os.Mkdir(configPath, 0755)
+	// vaultAddr present but certAuth fields missing
+	os.WriteFile(configPath+"/config.yml", []byte(`vaultAddr: "https://localhost:8200"`+"\n"), 0644)
+
+	_, err := LoadConfig(dir)
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Errorf("expected required-fields error, got %v", err)
+	}
+}
+
+func TestCreateLocalVaultClient_RejectsWorldReadableKey(t *testing.T) {
+	dir := t.TempDir()
+	os.Mkdir(dir+"/.yubivault", 0755)
+	os.WriteFile(dir+"/.yubivault/client-cert.key", []byte("dummy"), 0644)
+
+	appConfig := &AppConfig{
+		VaultAddr:       "https://localhost:8200",
+		CertAuthPemFile: "client-cert.pem",
+		CertAuthKeyFile: "client-cert.key",
+	}
+	if _, err := CreateLocalVaultClient(appConfig, dir); err == nil || !strings.Contains(err.Error(), "group/other") {
+		t.Errorf("expected permissions error, got %v", err)
+	}
+}
+
 func TestReadPin_Mock(t *testing.T) {
 	input := bytes.NewBufferString("123456\n")
 	pin, err := ReadPin("1234567", input)


### PR DESCRIPTION
  ## Summary

  Findings from a Trail of Bits security review (`insecure-defaults` + `sharp-edges`
  skills) applied to the Vault auth flow. Two themes: fail-secure handling of local
  config/keys, and fixing fragile YubiKey credential selection.

  No critical fail-open defaults were found; TLS verification is correctly non-optional
  and there are no hardcoded secrets. These changes harden the surrounding edges.

  ## Changes

  ### Reliable YubiKey credential selection (main change)
  Previously the code picked the signing key by numeric index (`yubikeyPivIndex`) but
  hardcoded the certificate to `certs[0]`, so any index other than 0 paired the wrong
  key with the wrong cert. The `yubikeyPivLabel` field was documented but never used.

  `crypto11.FindAllPairedCertificates()` already pairs each key with its certificate by
  `CKA_ID` (the PIV slot). We now use those pre-paired `tls.Certificate` values directly
  and select **by certificate Subject CN** via a new pure `selectCertificate` function:
  - exactly one credential → used automatically (no config);
  - multiple → `yubikeyCertCN` selects one, erroring (and listing available CNs) on
    ambiguity or no match — never silently authenticating as the wrong identity.

  **Config change:** `yubikeyPivIndex` and `yubikeyPivLabel` removed; optional
  `yubikeyCertCN` added. Existing configs are unaffected (`yaml.v2` ignores unknown keys).

  ### Local-mode hardening
  - Refuse a client private key that is group/other-readable (fail-secure), with a
    `chmod 600` hint.
  - Validate required config fields (`vaultAddr`, `certAuthName`, `certAuthMount`) up
    front. Scheme is intentionally not enforced so local dev Vault over http still works.
  - Guard against a negative `yubikeyPivIndex` (now removed entirely).
  - Fix README: `chmod` (not `chown`) for `~/.yubivault`.

  ## Testing
  - New hardware-free unit tests for `selectCertificate` (all 8 selection cases, asserting
    the returned identity — would catch the original `certs[0]` bug).
  - Key-permission rejection test made deterministic under any umask.
  - `go vet` / `go build` / `go test` clean; `gofmt` clean.

  ## Out of scope
  - Documented `TOKEN_PIN` env-var tradeoff (leak surface) — left as-is.
  - Inherent stat-then-read TOCTOU on the key file (not meaningfully mitigable).

  Reviewed end-to-end by an independent reviewer pass: no correctness or
  security-weakening defects; crypto11 context cleanup on all error paths confirmed.