### PR TITLE
ci: bump Actions to Node 24 runtimes and Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Cache Go modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,17 @@ jobs:
         goarch: [amd64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Build binary
         run: |
           mkdir -p dist
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags "-X 'main.Version=${{ github.ref_name }}'" -o dist/yubivault-${{ matrix.goos }}-${{ matrix.goarch }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: yubivault-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/yubivault-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: dist
       - name: Generate changelog

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/fatred/yubivault
 
-go 1.23.6
-
-toolchain go1.24.4
+go 1.26.0
 
 require github.com/hashicorp/vault-client-go v0.4.3
 


### PR DESCRIPTION
  Node 20 is deprecated on GitHub Actions runners:
  - actions/checkout          v4 -> v5
  - actions/setup-go          v5 -> v6
  - actions/upload-artifact   v4 -> v5
  - actions/download-artifact v4 -> v5

  Also bump the Go toolchain:
  - go.mod: go 1.23.6 -> 1.26.0, drop the pinned toolchain directive
  - CI/release go-version: 1.23 -> 1.26

  actions/cache@v4 and third-party actions unaffected. vet/build/test green
  on go1.26.5.